### PR TITLE
fix(docs): redirect LICENSE badge link to glair-vision-go repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 <p>
 
 <p align="center">
-    <a href="https://github.com/glair-ai/glair-vision-java/blob/main/LICENSE"><img src="https://img.shields.io/npm/l/@glair/vision" alt="License"></a>
+    <a href="https://github.com/glair-ai/glair-vision-go/blob/main/LICENSE"><img src="https://img.shields.io/npm/l/@glair/vision" alt="License"></a>
 </p>
 
 ## Requirement


### PR DESCRIPTION
## Overview

This pull request fixes `LICENSE` badge redirection to the correct repository in the `README` file.