### PR TITLE
docs: replace invalid error codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,12 +335,10 @@ func main() {
     		// is a glair.Error, assert the error code
 	  	if glairErr, ok := err.(*glair.Error); ok {
       		switch glairErr.Code {
-        		case glair.ErrorCodeInvalidFile:
-          			fmt.Println("Cannot read input file")
-        		case glair.ErrorCodeFileCorrupted:
-          			fmt.Println("File corrupted")
-        		case glair.ErrorCodeInvalidURL:
-          			fmt.Println("URL is invalid")
+        		case glair.ErrorCodeFileError:
+          			fmt.Println("Cannot read input file correctly")
+        		case glair.ErrorCodeNetworkError:
+          			fmt.Println("There are problems while connecting to GLAIR Vision API")
         		default:
           			fmt.Printf("GLAIR SDK returns error code: %d", glairErr.Code)
       			}

--- a/README.md
+++ b/README.md
@@ -381,7 +381,6 @@ By default, GLAIR Vision Go SDK does not log anything regardless of severity. Ho
 package main
 
 import (
-
 	"fmt"
 
 	"github.com/glair-ai/glair-vision-go"


### PR DESCRIPTION
## Overview

Closes #16 

This pull request updates the error handling code sample by replacing:

1. `InvalidFile` and `FileCorrupted` with `FileError`
2. `InvalidURL` with `NetworkError`

The error codes are changed since those codes don't exist anymore.