### PR TITLE
fix(identity): allow identity API to accept string pointer of DoB

### DIFF
--- a/identity.go
+++ b/identity.go
@@ -105,7 +105,7 @@ type FaceVerificationInput struct {
 	// DateOfBirth represents date of birth of the person to
 	// be verified
 	//
-	// DateOfBirth must be provided as a string with yyyy-mm-dd
+	// DateOfBirth must be provided as a string with dd-mm-yyyy
 	// format or as an instance of *time.Time
 	DateOfBirth interface{}
 }

--- a/identity/identity.go
+++ b/identity/identity.go
@@ -28,6 +28,8 @@ func parseDateOfBirth(dateOfBirth interface{}) *string {
 	switch dob := dateOfBirth.(type) {
 	case string:
 		return glair.String(dob)
+	case *string:
+		return dob
 	case time.Time:
 		return glair.String(dob.Format("02-01-2006"))
 	default:


### PR DESCRIPTION
## Overview

Closes #24 

This pull request modifies the date parsing function of Identity API to accept string pointers for date of birth.