### PR TITLE
refactor: transform all KTP method names to uppercase

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ func main() {
 
 	file, _ := os.Open("../images/ktp.jpeg")
 
-	result, err := client.Ocr.Ktp(contextWithTimeout, glair.OCRInput{
+	result, err := client.Ocr.KTP(contextWithTimeout, glair.OCRInput{
 		Image: file,
 	})
 

--- a/examples/ocr/ktp_sessions/main.go
+++ b/examples/ocr/ktp_sessions/main.go
@@ -17,7 +17,7 @@ func main() {
 	config := glair.NewConfig("", "", "")
 	client := client.New(config)
 
-	result, err := client.Ocr.KtpSessions(ctx, glair.SessionsInput{
+	result, err := client.Ocr.KTPSessions(ctx, glair.SessionsInput{
 		SuccessURL: "https://www.google.com",
 	})
 

--- a/ocr/ocr.go
+++ b/ocr/ocr.go
@@ -101,7 +101,7 @@ func New(config *glair.Config) *OCR {
 	}
 }
 
-// Ktp performs OCR on the given file using KTP model
+// KTP performs OCR on the given file using KTP model
 //
 // API Docs: https://docs.glair.ai/vision/ktp
 func (ocr *OCR) KTP(
@@ -125,7 +125,7 @@ func (ocr *OCR) KTP(
 	return internal.MakeMultipartRequest[KTP](ctx, params, ocr.config)
 }
 
-// KtpWithQuality performs OCR on the given file using KTP model
+// KTPWithQuality performs OCR on the given file using KTP model
 // and supplements it with file quality data
 //
 // API Docs: https://docs.glair.ai/vision/ktp
@@ -440,11 +440,11 @@ func (ocr *OCR) SKPR(
 	return internal.MakeMultipartRequest[SKPR](ctx, params, ocr.config)
 }
 
-// KtpSessions sends session request for passive liveness
+// KTPSessions sends session request for passive liveness
 // using the prebuilt web page
 //
 // API Docs: https://docs.glair.ai/vision/ktp-sessions
-func (ocr *OCR) KtpSessions(
+func (ocr *OCR) KTPSessions(
 	ctx context.Context,
 	input glair.SessionsInput,
 ) (glair.Session, error) {


### PR DESCRIPTION
## Overview

Closes #26 

This pull request transforms `KtpSessions` to `KTPSessions`. This change is initiated simply for naming consistency and does not change the underlying logic.