### PR TITLE
fix: replace hiccups

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 ## Requirement
 
-- Go 1.18 or later with Go modules.
+- Go 1.20 or later with Go modules.
 
 ## Installation
 

--- a/face.go
+++ b/face.go
@@ -1,6 +1,6 @@
 package glair
 
-// OCRInput stores parameters for Face Matching request
+// FaceMatchingInput stores parameters for Face Matching request
 type FaceMatchingInput struct {
 	// RequestID represents request identifier for debugging purposes
 	RequestID string


### PR DESCRIPTION
## Overview

This pull request fixes hiccups in the current documentation, specifically:

1. Updated Go version from `1.18` to `1.20` in `README.md`
2. Replace `OCRInput` with `FaceMatchingInput` for Face Matching Input type documentation